### PR TITLE
Fix theme toggle initialization

### DIFF
--- a/scripts/theme-toggle.js
+++ b/scripts/theme-toggle.js
@@ -2,16 +2,18 @@ document.addEventListener('DOMContentLoaded', function () {
     const themeToggle = document.querySelector('.theme-toggle');
     const body = document.body;
 
-    themeToggle.addEventListener('click', function () {
-        body.classList.toggle('dark-theme');
+    if (themeToggle) {
+        themeToggle.addEventListener('click', function () {
+            body.classList.toggle('dark-theme');
 
-        // Save the theme preference in localStorage
-        if (body.classList.contains('dark-theme')) {
-            localStorage.setItem('theme', 'dark');
-        } else {
-            localStorage.setItem('theme', 'light');
-        }
-    });
+            // Save the theme preference in localStorage
+            if (body.classList.contains('dark-theme')) {
+                localStorage.setItem('theme', 'dark');
+            } else {
+                localStorage.setItem('theme', 'light');
+            }
+        });
+    }
 
     // Load the saved theme preference
     if (localStorage.getItem('theme') === 'dark') {


### PR DESCRIPTION
## Summary
- avoid errors when theme toggle is missing by verifying element exists before attaching the click handler

## Testing
- `tail -c1 scripts/theme-toggle.js | od -An -t x1`

------
https://chatgpt.com/codex/tasks/task_e_68402fe8b2f88332bc418693b6a01ba9